### PR TITLE
Add SecurityKey Token

### DIFF
--- a/.github/workflows/main_azurativeautomations.yml
+++ b/.github/workflows/main_azurativeautomations.yml
@@ -1,0 +1,30 @@
+# Docs for the Azure Web Apps Deploy action: https://github.com/azure/functions-action
+# More GitHub Actions for Azure: https://github.com/Azure/actions
+
+name: Build and deploy Powershell project to Azure Function App - azurativeautomations
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.' # set this to the path to your web app project, defaults to the repository root
+
+jobs:
+  deploy:
+    runs-on: windows-latest
+    
+    steps:
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@v4
+      
+      - name: 'Run Azure Functions Action'
+        uses: Azure/functions-action@v1
+        id: fa
+        with:
+          app-name: 'azurativeautomations'
+          slot-name: 'Production'
+          package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+          publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_90B4086DB08D43B4B7DE91F405912F9F }}

--- a/ConnectWise-AddTicketNote/run.ps1
+++ b/ConnectWise-AddTicketNote/run.ps1
@@ -2,36 +2,39 @@
 
 .SYNOPSIS
     
-        This function is used to add a note to a ConnectWise ticket.
+    This function is used to add a note to a ConnectWise ticket.
 
 .DESCRIPTION
                     
-            This function is used to add a note to a ConnectWise ticket.
+    This function is used to add a note to a ConnectWise ticket.
                     
-            The function requires the following environment variables to be set:
+    The function requires the following environment variables to be set:
                     
-            ConnectWisePsa_ApiBaseUrl - Base URL of the ConnectWise API
-            ConnectWisePsa_ApiCompanyId - Company Id of the ConnectWise API
-            ConnectWisePsa_ApiPublicKey - Public Key of the ConnectWise API
-            ConnectWisePsa_ApiPrivateKey - Private Key of the ConnectWise API
-            ConnectWisePsa_ApiClientId - Client Id of the ConnectWise API
+    ConnectWisePsa_ApiBaseUrl - Base URL of the ConnectWise API
+    ConnectWisePsa_ApiCompanyId - Company Id of the ConnectWise API
+    ConnectWisePsa_ApiPublicKey - Public Key of the ConnectWise API
+    ConnectWisePsa_ApiPrivateKey - Private Key of the ConnectWise API
+    ConnectWisePsa_ApiClientId - Client Id of the ConnectWise API
+    SecurityKey - Optional, use this as an additional step to secure the function
                     
-            The function requires the following modules to be installed:
-                    
-            None        
+    The function requires the following modules to be installed:
+                   
+    None        
 
 .INPUTS
 
     TicketId - string value of numeric ticket number
     Message - text of note to add
     Internal - boolean indicating whether not should be internal only
+    SecurityKey - optional security key to secure the function
 
     JSON Structure
 
     {
         "TicketId": "123456",
         "Message": "This is a note",
-        "Internal": true
+        "Internal": true,
+        "SecurityKey", "optional"
     }
 
 .OUTPUTS
@@ -84,6 +87,12 @@ function Add-ConnectWiseTicketNote {
 $TicketId = $Request.Body.TicketId
 $Text = $Request.Body.Message
 $Internal = $Request.Body.Internal
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
 
 if (-Not $TicketId) {
     Write-Host "Missing ticket number"
@@ -112,7 +121,7 @@ $result = Add-ConnectWiseTicketNote -ConnectWiseUrl $env:ConnectWisePsa_ApiBaseU
 Write-Host $result.Message
 
 $body = @{
-    response = $result | ConvertTo-Json;
+    response = ($result | ConvertTo-Json);
 } 
 
 Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{

--- a/ConnectWise-SetTicketStatus/run.ps1
+++ b/ConnectWise-SetTicketStatus/run.ps1
@@ -54,7 +54,7 @@ function Set-ConnectWiseTicketStatus {
         [string]$PrivateKey,
         [string]$ClientId,
         [string]$TicketId,
-        [string]$Status
+        [string]$StatusName
     )
 
     # Construct the API endpoint for adding a note
@@ -75,13 +75,17 @@ function Set-ConnectWiseTicketStatus {
 
     Write-Host ($ticket | ConvertTo-Json)
 
-    $boardUrl = "$ConnectWiseUrl/v4_6_release/apis/3.0/service/boards/${ticket.board.id}/statuses?pageSize=100"
+    #boardId = $ticket.board.id
 
-    Write-Host $boardUrl
+    $boardUrl = "$ConnectWiseUrl/v4_6_release/apis/3.0/service/boards/$boardId/statuses?pageSize=100"
 
     $statuses = Invoke-RestMethod -Uri $boardUrl -Method Get -Headers $headers
     
     $status = $Statuses | Where-Object { $_.name -eq $StatusName }
+
+    Write-Host ($status | ConvertTo-Json)
+
+    $statusId = $status.id
 
     $operationList = @()
     $operation = @{
@@ -137,7 +141,7 @@ $result = Set-ConnectWiseTicketStatus -ConnectWiseUrl $env:ConnectWisePsa_ApiBas
     -PrivateKey $env:ConnectWisePsa_ApiPrivateKey `
     -ClientId $env:ConnectWisePsa_ApiClientId `
     -TicketId $TicketId `
-    -Status = $Status
+    -StatusName $Status
 
 Write-Host $result.Message
 

--- a/ConnectWise-SetTicketStatus/run.ps1
+++ b/ConnectWise-SetTicketStatus/run.ps1
@@ -98,7 +98,7 @@ function Set-ConnectWiseTicketStatus {
     $operationList += $operation
     
     # Make the API request to change the status, use the -InputOption option to keep PowerShell from flattening the list
-    $result = Invoke-RestMethod -Uri $apiUrl -Method Patch -Headers $headers -Body -Body (ConvertTo-Json -InputObject $operationList)
+    $result = Invoke-RestMethod -Uri $apiUrl -Method Patch -Headers $headers -Body (ConvertTo-Json -InputObject $operationList)
     Write-Host $result
     return $result
 }

--- a/ConnectWise-SetTicketStatus/run.ps1
+++ b/ConnectWise-SetTicketStatus/run.ps1
@@ -75,8 +75,9 @@ function Set-ConnectWiseTicketStatus {
 
     Write-Host ($ticket | ConvertTo-Json)
 
-    #boardId = $ticket.board.id
+    $boardId = $ticket.board.id
 
+    # be sure to include pageSize to get all the statuses, by default it only returns 25
     $boardUrl = "$ConnectWiseUrl/v4_6_release/apis/3.0/service/boards/$boardId/statuses?pageSize=100"
 
     $statuses = Invoke-RestMethod -Uri $boardUrl -Method Get -Headers $headers
@@ -87,6 +88,7 @@ function Set-ConnectWiseTicketStatus {
 
     $statusId = $status.id
 
+    # Construct the operation to update the status, must be in list form for the API
     $operationList = @()
     $operation = @{
         op = "replace"
@@ -95,7 +97,7 @@ function Set-ConnectWiseTicketStatus {
     }
     $operationList += $operation
     
-    # Make the API request to add the note
+    # Make the API request to change the status, use the -InputOption option to keep PowerShell from flattening the list
     $result = Invoke-RestMethod -Uri $apiUrl -Method Patch -Headers $headers -Body -Body (ConvertTo-Json -InputObject $operationList)
     Write-Host $result
     return $result

--- a/ConnectWise-SetTicketStatus/run.ps1
+++ b/ConnectWise-SetTicketStatus/run.ps1
@@ -2,36 +2,39 @@
 
 .SYNOPSIS
     
-        This function is used to set the status of a ConnectWise ticket based on the result code.
+    This function is used to set the status of a ConnectWise ticket based on the result code.
 
 .DESCRIPTION
                 
-        This function is used to set the status of a ConnectWise ticket based on the result code.
+    This function is used to set the status of a ConnectWise ticket based on the result code.
                 
-        The function requires the following environment variables to be set:
+    The function requires the following environment variables to be set:
                 
-        ConnectWisePsa_ApiBaseUrl - Base URL of the ConnectWise API
-        ConnectWisePsa_ApiCompanyId - Company Id of the ConnectWise API
-        ConnectWisePsa_ApiPublicKey - Public Key of the ConnectWise API
-        ConnectWisePsa_ApiPrivateKey - Private Key of the ConnectWise API
-        ConnectWisePsa_ApiClientId - Client Id of the ConnectWise API
-        ConnectWisePsa_ApiStatusClosed - Status to set when result code is 200
-        ConnectWisePsa_ApiStatusOpen - Status to set when result code is not 200
+    ConnectWisePsa_ApiBaseUrl - Base URL of the ConnectWise API
+    ConnectWisePsa_ApiCompanyId - Company Id of the ConnectWise API
+    ConnectWisePsa_ApiPublicKey - Public Key of the ConnectWise API
+    ConnectWisePsa_ApiPrivateKey - Private Key of the ConnectWise API
+    ConnectWisePsa_ApiClientId - Client Id of the ConnectWise API
+    ConnectWisePsa_ApiStatusClosed - Status to set when result code is 200
+    ConnectWisePsa_ApiStatusOpen - Status to set when result code is not 200
+    SecurityKey - Optional, use this as an additional step to secure the function
+        
+    The function requires the following modules to be installed:
                 
-        The function requires the following modules to be installed:
-                
-        None    
+    None    
 
 .INPUTS
 
     TicketId - string value of numeric ticket number
     ResultCode - numeric value of result code, 200 = success
+    SecurityKey - optional security key to secure the function
 
     JSON Structure
 
     {
         "TicketId": "123456"
-        "ResultCode": 200
+        "ResultCode": 200,
+        "SecurityKey", "optional"
     }
 
 .OUTPUTS
@@ -57,21 +60,39 @@ function Set-ConnectWiseTicketStatus {
     # Construct the API endpoint for adding a note
     $apiUrl = "$ConnectWiseUrl/v4_6_release/apis/3.0/service/tickets/$TicketId"
 
-    $statusPayload = @{
-        status = @{
-            name = $Status
-        }
-    } | ConvertTo-Json
-    
+    # ConnectWise API requires the status to be an ID value
+    # Each board has its own status values, so we need to get the ticket to find the right board,
+    #   and then get the status ID from the board based on the name of the status 
+
     # Set up the authentication headers
     $headers = @{
         "Authorization" = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("${PublicKey}:${PrivateKey}"))
         "Content-Type" = "application/json"
-        "clientId" = $ClientId
+        "ClientId" = $ClientId
     }
+    
+    $ticket = Invoke-RestMethod -Uri $apiUrl -Method Get -Headers $headers
 
+    Write-Host ($ticket | ConvertTo-Json)
+
+    $boardUrl = "$ConnectWiseUrl/v4_6_release/apis/3.0/service/boards/${ticket.board.id}/statuses?pageSize=100"
+
+    Write-Host $boardUrl
+
+    $statuses = Invoke-RestMethod -Uri $boardUrl -Method Get -Headers $headers
+    
+    $status = $Statuses | Where-Object { $_.name -eq $StatusName }
+
+    $operationList = @()
+    $operation = @{
+        op = "replace"
+        path = "status/id"
+        value = "$statusId"
+    }
+    $operationList += $operation
+    
     # Make the API request to add the note
-    $result = Invoke-RestMethod -Uri $apiUrl -Method Patch -Headers $headers -Body $statusPayload
+    $result = Invoke-RestMethod -Uri $apiUrl -Method Patch -Headers $headers -Body -Body (ConvertTo-Json -InputObject $operationList)
     Write-Host $result
     return $result
 }
@@ -79,6 +100,12 @@ function Set-ConnectWiseTicketStatus {
 $TicketId = $Request.Body.TicketId
 $StatusClosed = $env:ConnectWisePsa_ApiStatusClosed
 $StatusOpen = $env:ConnectWisePsa_ApiStatusOpen
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
 
 if (-Not $TicketId) {
     Write-Host "Missing ticket number"
@@ -115,7 +142,7 @@ $result = Set-ConnectWiseTicketStatus -ConnectWiseUrl $env:ConnectWisePsa_ApiBas
 Write-Host $result.Message
 
 $body = @{
-    response = $result | ConvertTo-Json;
+    response = ($result | ConvertTo-Json);
 } 
 
 Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{

--- a/Ms365-AddGroupUser/run.ps1
+++ b/Ms365-AddGroupUser/run.ps1
@@ -24,6 +24,7 @@
     GroupName - group name that exists in the tenant
     TenantId - string value of the tenant id, if blank uses the environment variable Ms365_TenantId
     TicketId - optional - string value of the ticket id used for transaction tracking
+    SecurityKey - Optional, use this as an additional step to secure the function
 
     JSON Structure
 
@@ -31,10 +32,13 @@
         "UserEmail": "email@address.com",
         "GroupName": "Group Name",
         "TenantId": "12345678-1234-1234-123456789012",
-        "TicketId": "123456
+        "TicketId": "123456,
+        "SecurityKey", "optional"
     }
 
 .OUTPUTS 
+
+    JSON response with the following fields:
 
     Message - Descriptive string of result
     TicketId - TicketId passed in Parameters
@@ -56,6 +60,12 @@ $UserEmail = $Request.Body.UserEmail
 $GroupName = $Request.Body.GroupName
 $TenantId = $Request.Body.TenantId
 $TicketId = $Request.Body.TicketId
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
 
 if (-Not $userEmail) {
     $message = "UserEmail cannot be blank."

--- a/Ms365-NewGroup/run.ps1
+++ b/Ms365-NewGroup/run.ps1
@@ -2,18 +2,19 @@
 
 .SYNOPSIS
     
-    This function is used to add a user to a group in Microsoft 365.
+    This function is to create a new group in Microsoft 365.
 
 .DESCRIPTION
     
-    This function is used to add a user to a group in Microsoft 365.
+    This function is to create a new group in Microsoft 365.
     
     The function requires the following environment variables to be set:
     
     Ms365_AuthAppId - Application Id of the service principal
     Ms365_AuthSecretId - Secret Id of the service principal
     Ms365_TenantId - Tenant Id of the Microsoft 365 tenant
-    
+    SecurityKey - Optional, use this as an additional step to secure the function
+ 
     The function requires the following modules to be installed:
     
     Microsoft.Graph
@@ -24,6 +25,7 @@
     GroupDescription - group description
     TenantId - string value of the tenant id, if blank uses the environment variable Ms365_TenantId
     TicketId - optional - string value of the ticket id used for transaction tracking
+    SecurityKey - Optional, use this as an additional step to secure the function
 
     JSON Structure
 
@@ -31,10 +33,13 @@
         "GroupName": "Group Name",
         "GroupDescription": "Group Description",
         "TenantId": "12345678-1234-1234-123456789012",
-        "TicketId": "123456
+        "TicketId": "123456,
+        "SecurityKey", "optional"
     }
 
 .OUTPUTS
+
+    JSON response with the following fields:
 
     Message - Descriptive string of result
     TicketId - TicketId passed in Parameters
@@ -56,6 +61,12 @@ $GroupName = $Request.Body.GroupName
 $GroupDescription = $Request.Body.GroupDescription
 $TenantId = $Request.Body.TenantId
 $TicketId = $Request.Body.TicketId
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
 
 if (-Not $GroupName) {
     $message = "GroupName cannot be blank."

--- a/Ms365-NewUserLikeUser/run.ps1
+++ b/Ms365-NewUserLikeUser/run.ps1
@@ -1,26 +1,45 @@
 <# 
 
-Ms365-CreateUserLikeUser
+.SYNOPSIS
+    
+    This function is used to add a note to a ConnectWise ticket.
 
-This function creates a new user in the tenant with the same licenses and group memberships as an existing user.
+.DESCRIPTION
 
-Parameters
+    This function creates a new user in the tenant with the same licenses and group memberships as an existing user.
+
+    The function requires the following environment variables to be set:
+
+    Ms365_AuthAppId - Application Id of the service principal
+    Ms365_AuthSecretId - Secret Id of the service principal
+    Ms365_TenantId - Tenant Id of the Microsoft 365 tenant
+    SecurityKey - Optional, use this as an additional step to secure the function
+
+    The function requires the following modules to be installed:
+    
+    Microsoft.Graph
+
+.INPUTS
 
     UserEmail - user email address that exists in the tenant
     GroupName - group name that exists in the tenant
     TenantId - string value of the tenant id, if blank uses the environment variable Ms365_TenantId
     TicketId - optional - string value of the ticket id used for transaction tracking
+    SecurityKey - Optional, use this as an additional step to secure the function
 
-JSON Structure
+    JSON Structure
 
     {
         "UserEmail": "email@address.com",
         "GroupName": "Group Name",
         "TenantId": "12345678-1234-1234-123456789012",
-        "TicketId": "123456
+        "TicketId": "123456,
+        "SecurityKey", "optional"
     }
 
-Return Results 
+.OUTPUTS
+
+    JSON response with the following fields:
 
     Message - Descriptive string of result
     TicketId - TicketId passed in Parameters
@@ -43,10 +62,14 @@ $ExistingUserEmail = $Request.Body.ExistingUserEmail
 $NewUserFirstName = $Request.Body.NewUserFirstName
 $NewUserLastName = $Request.Body.NewUserLastName
 $NewUserDisplayName = $Request.Body.NewUserDisplayName
-
-
 $TenantId = $Request.Body.TenantId
 $TicketId = $Request.Body.TicketId
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
 
 if (-Not $userEmail) {
     $message = "UserEmail cannot be blank."

--- a/Ms365-RemoveGroupUser/run.ps1
+++ b/Ms365-RemoveGroupUser/run.ps1
@@ -6,17 +6,18 @@
 
 .DESCRIPTION
             
-        This function is used to remove a user from a distribution group in Microsoft 365.
+    This function is used to remove a user from a distribution group in Microsoft 365.
         
-        The function requires the following environment variables to be set:
+    The function requires the following environment variables to be set:
         
-        Ms365_AuthAppId - Application Id of the service principal
-        Ms365_AuthSecretId - Secret Id of the service principal
-        Ms365_TenantId - Tenant Id of the Microsoft 365 tenant
+    Ms365_AuthAppId - Application Id of the service principal
+    Ms365_AuthSecretId - Secret Id of the service principal
+    Ms365_TenantId - Tenant Id of the Microsoft 365 tenant
+    SecurityKey - Optional, use this as an additional step to secure the function
         
-        The function requires the following modules to be installed:
-        
-        Microsoft.Graph
+    The function requires the following modules to be installed:
+       
+    Microsoft.Graph
 
 .INPUTS
 
@@ -24,6 +25,7 @@
     GroupName - group name that exists in the tenant
     TenantId - string value of the tenant id, if blank uses the environment variable Ms365_TenantId
     TicketId - optional - string value of the ticket id used for transaction tracking
+    SecurityKey - Optional, use this as an additional step to secure the function
 
     JSON Structure
 
@@ -31,10 +33,13 @@
         "UserEmail": "email@address.com",
         "GroupName": "Group Name",
         "TenantId": "12345678-1234-1234-123456789012",
-        "TicketId": "123456
+        "TicketId": "123456,
+        "SecurityKey", "optional"
     }
 
 .OUTPUTS
+
+    JSON response with the following fields:
 
     Message - Descriptive string of result
     TicketId - TicketId passed in Parameters
@@ -56,6 +61,12 @@ $UserEmail = $Request.Body.UserEmail
 $GroupName = $Request.Body.GroupName
 $TenantId = $Request.Body.TenantId
 $TicketId = $Request.Body.TicketId
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
 
 if (-Not $userEmail) {
     $message = "UserEmail cannot be blank."

--- a/Ms365-UpdateCsaCompanyTokens/run.ps1
+++ b/Ms365-UpdateCsaCompanyTokens/run.ps1
@@ -15,26 +15,34 @@
     Ms365_TenantId - Tenant Id of the Azure AD application
     CloudRadialCsa_ApiPublicKey - Public Key of the CloudRadial API
     CloudRadialCsa_ApiPrivateKey - Private Key of the CloudRadial API
-    
+    SecurityKey - Optional, use this as an additional step to secure the function
+
     The function requires the following modules to be installed:
     
     Microsoft.Graph     
 
 .INPUTS
 
-    companyId - numeric company id
-    tenantId - string value of the tenant id, if blank uses the environment variable Ms365_TenantId
+    CompanyId - numeric company id
+    TenantId - string value of the tenant id, if blank uses the environment variable Ms365_TenantId
+    SecurityKey - Optional, use this as an additional step to secure the function
 
     JSON Structure
 
     {
-        "companyId": "12"
-        "tenantId": "12345678-1234-1234-1234-123456789012"
+        "CompanyId": "12"
+        "TenantId": "12345678-1234-1234-1234-123456789012",
+        "SecurityKey", "optional"
     }
 
 .OUTPUTS
 
-    A JSON result of the function
+    JSON response with the following fields:
+
+    Message - Descriptive string of result
+    TicketId - TicketId passed in Parameters
+    ResultCode - 200 for success, 500 for failure
+    ResultStatus - "Success" or "Failure"
 
 #>
 
@@ -74,12 +82,19 @@ function Set-CloudRadialToken {
     Write-Host "API response: $($response | ConvertTo-Json -Depth 4)"
 }
 
-$companyId = $Request.Body.companyId
-$tenantId = $Request.Body.tenantId
+$companyId = $Request.Body.CompanyId
+$tenantId = $Request.Body.TenantId
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
 
 if (-Not $companyId) {
     $companyId = 1
 }
+
 if (-Not $tenantId) {
     $tenantId = $env:Ms365_TenantId
 }

--- a/PwPush-CreateNewPassword/run.ps1
+++ b/PwPush-CreateNewPassword/run.ps1
@@ -2,30 +2,35 @@
 
 .SYNOPSIS
 
-        This function is used to create a new password and send it to the user using the PwPush API
+    This function is used to create a new password and send it to the user using the PwPush API
 
 .DESCRIPTION
 
-        This function is used to create a new password and send it to the user using the PwPush API.
+    This function is used to create a new password and send it to the user using the PwPush API.
 
-        It is a demonstration of using the PwPush API and can be adapted as needed.
+    It is a demonstration of using the PwPush API and can be adapted as needed.
 
-        The function requires the following environment variables to be set:
+    The function requires the following environment variables to be set:
 
-        PwPush_ApiEmail - Email address of the PwPush API user
-        PwPush_ApiKey - API Key
+    PwPush_ApiEmail - Email address of the PwPush API user
+    PwPush_ApiKey - API Key
+    SecurityKey - Optional, use this as an additional step to secure the function
 
 .INPUTS
 
     TicketId - optional - string value of the ticket id used for transaction tracking
+    SecurityKey - optional security key to secure the function
 
     JSON Structure
 
     {
-        "TicketId": "123456"
+        "TicketId": "123456",
+        "SecurityKey", "optional"
     }
 
 .OUTPUTS
+
+    JSON response with the following fields:
 
     Message - Descriptive string of result
     TicketId - TicketId passed in Parameters
@@ -107,6 +112,13 @@ function Generate-RandomPassword {
 }
 
 $TicketId = $Request.Body.TicketId
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
+
 if (-Not $TicketId) {
     $TicketId = ""
 }

--- a/Utility-SetFormattedEmail/run.ps1
+++ b/Utility-SetFormattedEmail/run.ps1
@@ -13,7 +13,9 @@
     Ms365_AuthAppId - Application Id of the service principal
     Ms365_AuthSecretId - Secret Id of the service principal
     Ms365_TenantId - Tenant Id of the Microsoft 365 tenant
-        
+    CloudradialCsa_PortalUrl - Base URL of the CloudRadial CSA tenant
+    SecurityKey - Optional, use this as an additional step to secure the function
+   
     The function requires the following modules to be installed:
         
     Microsoft.Graph
@@ -22,12 +24,14 @@
     
     Message - text of message to place in email
     TicketId - optional - string value of the ticket id used for transaction tracking
+    SecurityKey - optional security key to secure the function
 
     JSON Structure
 
     {
         "Message": "This is the message"
-        "TicketId": "123456
+        "TicketId": "123456,
+        "SecurityKey", "optional"
     }
 
 .OUTPUTS
@@ -40,11 +44,20 @@ using namespace System.Net
 
 param($Request, $TriggerMetadata)
 
+$TicketId = $Request.Body.TicketId
+$PortalUrl = $env:CloudRadialCsa_PortalUrl
+$SecurityKey = $env:SecurityKey
+
+if ($SecurityKey -And $SecurityKey -ne $Request.Headers.SecurityKey) {
+    Write-Host "Invalid security key"
+    break;
+}
+
 $body = @"
 
 <p>The request you submitted has been processed.</p>
 <p>$($Request.Body.Message)</p>
-<p>If you have any questions on this request, please refer to ticket number # $($Request.Body.TicketId).</p>
+<p>If you have any questions on this request, please refer to ticket number # <a target="_blank" href="$PortalUrl/app/service/status/$TicketId">$TicketId</a>.</p>
 
 "@
 


### PR DESCRIPTION
This commit:

- Adds a SecurityKey token that can be used along with a Partner-level token in the CloudRadial CSA to add an extra layer of security. In this case, if a tech leaves, a partner can update only the SecurityKey token in CloudRadial CSA and the SecurityKey application setting (environment string) in the FunctionApp without having to regenerate new URLs for all functions.
- Fixes problems with the ConnectWise set status function
- Cleans up the documentation in the functions